### PR TITLE
fix: the initial QC unit tests should pass

### DIFF
--- a/src/main/java/net/ipmdecisions/weather/qc/ThresholdData.java
+++ b/src/main/java/net/ipmdecisions/weather/qc/ThresholdData.java
@@ -28,7 +28,7 @@ public class ThresholdData {
      */
     public JSONObject getThresholdDataObject(String parameterID) {
         
-        return findFromJSONArray(getThresholdData("RESOURCE_READER", new JSONObject("{\"resource_path\":\"/thresholddata.json\"}")), parameterID);
+        return findFromJSONArray(getThresholdData("RESOURCE_READER", new JSONObject("{\"resource_path\":\"thresholddata.json\"}")), parameterID);
           
     }
     

--- a/src/test/java/net/ipmdecisions/weather/qc/QualityControlTest.java
+++ b/src/test/java/net/ipmdecisions/weather/qc/QualityControlTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import net.ipmdecisions.weather.entity.LocationWeatherData;
 
 //import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,6 +22,7 @@ import net.ipmdecisions.weather.entity.WeatherData;
 import net.ipmdecisions.weather.util.FileUtils;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class QualityControlTest {
     
@@ -53,12 +56,15 @@ public class QualityControlTest {
         WeatherData testData = oMapper.readValue(weatherDataJson, WeatherData.class);
         
         QualityControlMethods instance = new QualityControlMethods();
-        WeatherData result = instance.getQC(testData, "RT");
-         
+        WeatherData wd = instance.getQC(testData, "RT");
+        List<LocationWeatherData> lwd = wd.getLocationWeatherData();
+        Integer[] result = lwd.get(0).getQC();
+        
         Integer[] expResult = {2,2,2,2,2,2,2,2,2,2,2}; // All tests passed ok
         
-        assertEquals(expResult,result);
+        assertArrayEquals(expResult,result);
     }
+    
     /*
     @Test
     public void testRTQualityControlFail() throws Exception{


### PR DESCRIPTION
Fixed the initial QC unit test, so that it should pass.

This required two changes:

* changed `ThresholdData.java` to use a relative path when opening the `threshholddata.json` resource file. Earlier, the file wasn't found correctly when running tests, as the path was declared as an absolute path.  
  * I'm not completely sure if this is a good change, given that my Java skills are relatively rusty. I'm not sure if the problem was due to a typo in the path (meaning it never worked properly), or if it is due to some quirk in the way java finds resources in different modes such as building and testing (in which case it might have worked when running the app, but not when running tests). I haven't tested if this change breaks things when the project is build/run. But at least it works when running tests.
* changed the unit test to read data from `LocationWeatherData` instance (available from the original `Weatherdata` instance). This was needed, as the method `QualityControlMethods.getQC` doesn't return the QC values as the method's name would suggest.  