### PR TITLE
Feat: Changes to quality control threshold values

### DIFF
--- a/src/main/java/net/ipmdecisions/weather/qc/README.md
+++ b/src/main/java/net/ipmdecisions/weather/qc/README.md
@@ -1,0 +1,54 @@
+# Quality control
+
+## Thresholds
+
+Thresholds for different QC tests are defined in the resource file 
+`thresholddata.json` found in `src/main/resources`.
+
+### Interval test
+
+#### Min and max limits - `lower_limit` and `upper_limit`
+
+Interval test uses thresholds `lower_limit` and `upper_limit` to define the 
+minimum and maximum values allowed for a weather parameter.
+
+These thresholds are exclusive, meaning any value equal to (or smaller for 
+`lower_limit` and greater for `upper_limit`) is consider invalid.
+
+There are no default values for either of these thresholds - a weather 
+parameter missing the threshold values should be considered always valid for 
+interval QC testing.
+
+### Step test
+
+#### Step threshold size - `step_test_threshold`
+
+Step test uses the threshold value `step_test_threshold` for defining 
+threshold between valid and invalid step sizes. 
+
+This threshold is exclusive, meaning that any value the size of the threshold 
+(or over) is considered invalid. 
+
+There is no default threshold for `step_test_threshold`. Any weather parameter
+missing the `step_test_threshold` is considered to be valid for all steps.
+
+#### Step threshold type - `step_test_threshold_type`
+
+In addition, step test uses the value `step_test_threshold_type` to define 
+whether step size should be compared using either `absolute` or `relative` 
+size of the step.
+
+### Freeze test
+
+#### Freeze length threshold - `freeze_test_threshold`
+
+Freeze QC test uses `freeze_test_threshold` for defining a threshold between
+valid and invalid freeze lengths.
+
+This threshold is incluside, and defines the largest valid threshold for 
+consecutive hours of value freeze for a weather parameter in freeze QC test. 
+Any values over the threshold are considered invalid.
+
+There is a default threshold of 5 consecutive hours for `freeze_test_threshold`.
+If no `freeze_test_threshold` is defined for a weather parameter, the default
+value of 5 is considered as its inclusive threshold.

--- a/src/main/resources/thresholddata.json
+++ b/src/main/resources/thresholddata.json
@@ -12,7 +12,7 @@
         "id_array":["1021","1022","1023","1024"],
         "lower_limit":-40,
         "upper_limit":50,
-        "step_test_threshold": 2,
+        "step_test_threshold": 7.5,
         "step_test_threshold_type": "absolute"
     },
     {
@@ -85,26 +85,26 @@
     },
     {
         "parameter":"Wind speed",
-        "id_array":["4002"],
-        "lower_limit":0,
-        "upper_limit":76,
-        "step_test_threshold": 13,
+        "id_array":["4002, 4012"],
+        "lower_limit": 0,
+        "upper_limit": 76,
+        "step_test_threshold": 60,
         "step_test_threshold_type": "absolute"
     },
     {
         "parameter":"Wind speed",
         "id_array":["4003","4004","4005"],
-        "lower_limit":0,
-        "upper_limit":22,
+        "lower_limit": 0,
+        "upper_limit": 22,
         "step_test_threshold": 40,
         "step_test_threshold_type": "absolute"
     },
     {
         "parameter":"Wind speed",
-        "id_array":["4012","4013","4014","4015"],
-        "lower_limit":0,
-        "upper_limit":50,
-        "step_test_threshold": 13,
+        "id_array":["4013","4014","4015"],
+        "lower_limit": 0,
+        "upper_limit": 30,
+        "step_test_threshold": 40,
         "step_test_threshold_type": "absolute"
     },
     {

--- a/src/main/resources/thresholddata.json
+++ b/src/main/resources/thresholddata.json
@@ -85,7 +85,23 @@
     },
     {
         "parameter":"Wind speed",
-        "id_array":["4002","4003","4004","4005","4012","4013","4014","4015"],
+        "id_array":["4002"],
+        "lower_limit":0,
+        "upper_limit":76,
+        "step_test_threshold": 13,
+        "step_test_threshold_type": "absolute"
+    },
+    {
+        "parameter":"Wind speed",
+        "id_array":["4003","4004","4005"],
+        "lower_limit":0,
+        "upper_limit":22,
+        "step_test_threshold": 40,
+        "step_test_threshold_type": "absolute"
+    },
+    {
+        "parameter":"Wind speed",
+        "id_array":["4012","4013","4014","4015"],
         "lower_limit":0,
         "upper_limit":50,
         "step_test_threshold": 13,

--- a/src/main/resources/thresholddata.json
+++ b/src/main/resources/thresholddata.json
@@ -20,7 +20,7 @@
         "id_array":["1101","1102"],
         "lower_limit":-30,
         "upper_limit":40,
-        "step_test_threshold": 2,
+        "step_test_threshold": 5,
         "step_test_threshold_type": "absolute"
     },
     {
@@ -28,7 +28,7 @@
         "id_array":["1111","1112"],
         "lower_limit":-20,
         "upper_limit":40,
-        "step_test_threshold": 2,
+        "step_test_threshold": 5,
         "step_test_threshold_type": "absolute"
     },
     {

--- a/src/main/resources/thresholddata.json
+++ b/src/main/resources/thresholddata.json
@@ -11,13 +11,17 @@
         "parameter":"Temperature in canopy",
         "id_array":["1021","1022","1023","1024"],
         "lower_limit":-40,
-        "upper_limit":50
+        "upper_limit":50,
+        "step_test_threshold": 2,
+        "step_test_threshold_type": "absolute"
     },
     {
         "parameter":"Soil temperature -5 cm",
         "id_array":["1101","1102"],
         "lower_limit":-30,
-        "upper_limit":40
+        "upper_limit":40,
+        "step_test_threshold": 2,
+        "step_test_threshold_type": "absolute"
     },
     {
         "parameter":"Soil temperature -10 cm",

--- a/src/main/resources/thresholddata.json
+++ b/src/main/resources/thresholddata.json
@@ -97,6 +97,7 @@
         "parameter":"Solar radiation",
         "id_array":["5001"],
         "lower_limit":-25,
-        "upper_limit":1500
+        "upper_limit":1500,
+        "freeze_test_threshold": 12
     }
 ]

--- a/src/main/resources/thresholddata.json
+++ b/src/main/resources/thresholddata.json
@@ -71,7 +71,7 @@
         "lower_limit":0,
         "upper_limit":103,
         "step_test_threshold": 30,
-        "step_test_threshold_type": "relative"
+        "step_test_threshold_type": "absolute"
     },
     {
         "parameter":"Leaf wetness",


### PR DESCRIPTION
Changes to QC thresholds. Addition of missing threshold values, and corrections to incorrect threshold values.

Better explanation of changes can be found in the individual commit messages.

To do:

* [x] Review that values changed and added are correct.
* [x] Fixed: ~Weather parameters in the series' "temperature in canopy" and "soil temperature -5 cm" contain placeholder data, copied from "soil temperature -10 cm". Their values need to be changed, if not incidentally correct due to a happy accident.~
