### PR TITLE
Adding apache logging, fixing Davis Fruit test and adding correct params for SLU

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,16 +110,11 @@
             <artifactId>json</artifactId>
             <version>20231013</version>
         </dependency>
-        
+
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.3.5</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-apache-httpclient</artifactId>
+            <version>3.29.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.ws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
             <version>4.5.13</version>
         </dependency>
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.3.5</version>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.ws</groupId>
             <artifactId>jakarta.xml.ws-api</artifactId>
             <version>4.0.2</version>

--- a/postman_tests/IPM Decisions Weather API tests.postman_collection.json
+++ b/postman_tests/IPM Decisions Weather API tests.postman_collection.json
@@ -274,12 +274,12 @@
                 },
                 {
                   "key": "timeStart",
-                  "value": "2024-01-10",
+                  "value": "2025-10-10",
                   "type": "text"
                 },
                 {
                   "key": "timeEnd",
-                  "value": "2024-01-15",
+                  "value": "2025-10-15",
                   "type": "text"
                 },
                 {
@@ -323,12 +323,12 @@
                 },
                 {
                   "key": "timeStart",
-                  "value": "2022-01-02",
+                  "value": "2025-10-02",
                   "disabled": true
                 },
                 {
                   "key": "timeEnd",
-                  "value": "2022-01-10",
+                  "value": "2025-10-10",
                   "disabled": true
                 },
                 {

--- a/src/main/java/net/ipmdecisions/weather/datasourceadapters/SLULantMetAdapter.java
+++ b/src/main/java/net/ipmdecisions/weather/datasourceadapters/SLULantMetAdapter.java
@@ -73,8 +73,8 @@ public class SLULantMetAdapter {
 	 * include. Set to 0 to get exactly one point
 	 */
 	private final static String SLU_API_URL = "https://www.ffe.slu.se/lm/json/LantmetDWL.cfm"
-			+ "?centerWGS84n=%d"
-			+ "&centerWGS84e=%d"
+			+ "?WGS84n=%d"
+			+ "&WGS84e=%d"
 			+ "&outputType=JSON"
 			+ "&inputType=GRID"
 			+ "&logIntervalId=%d"


### PR DESCRIPTION
Apache logging is required for the MetosAPIAdapter to work specifically for the SSL stuff: 
```
SSLContextBuilder builder = new SSLContextBuilder();
            builder.loadTrustMaterial(null, new TrustStrategy() {
                    @Override
                    public boolean isTrusted(X509Certificate[] chain, String authType) throws CertificateException {
                    return true;
                }
            });

            SSLConnectionSocketFactory sslSF = new SSLConnectionSocketFactory(builder.build(),
            SSLConnectionSocketFactory.getDefaultHostnameVerifier());

            HttpClient client = HttpClients.custom().setSSLSocketFactory(sslSF).build();

```

SLU is now returning a response from their endpoint with this change in param, but a complete different object is being returned that expected. Will update the relevent Jira ticket with more details